### PR TITLE
fix(logger): hide auth token from logs

### DIFF
--- a/lib/msd_odata/auth.rb
+++ b/lib/msd_odata/auth.rb
@@ -4,11 +4,11 @@ module MsdOdata
 
     def initialize(tenant_id, options = {}, base_url = "https://login.microsoftonline.com")
       @url = "#{base_url}/#{tenant_id}/oauth2/token"
-      @options = { body: options }      
+      @options = { body: options }
     end
 
     def token
-      Client.new(url).request(:post, options)
+      Client.new(url, log_data: false).request(:post, options)
     end
   end
 end

--- a/lib/msd_odata/client.rb
+++ b/lib/msd_odata/client.rb
@@ -6,15 +6,18 @@ module MsdOdata
     include MsdOdata::Util::Logging
     attr_reader :url
 
-    def initialize(url)
+    def initialize(url, log_data: true)
       @url = url
+      @log_data = log_data
     end
 
     def request(method, options = {})
       log '----------CLIENT: MSD API REQUEST----------'
       log "METHOD => #{method}"
-      log "RESOURCE => #{url}"
-      log "OPTIONS => #{options}"
+      if @log_data
+        log "RESOURCE => #{url}"
+        log "OPTIONS => #{options.except(:headers)}"
+      end
 
       resp = Faraday.send(method, url) do |req|
         req.headers = options[:headers] if options[:headers]
@@ -24,13 +27,13 @@ module MsdOdata
                       else
                         options[:body]
                       end
-                    end 
+                    end
       end
       response = { status: json_format(resp.env.status.to_s), response_body: json_format(resp.env.response.body) }
 
       log '------CLIENT: MSD API RESPONSE------'
       log "RESPONSE CODE => #{response[:status]}"
-      log "RESPONSE BODY => #{response[:response_body]}"
+      log "RESPONSE BODY => #{response[:response_body]}" if @log_data
 
       response
     end


### PR DESCRIPTION
Excluded the headers from the logs completely, but noticed that In case of Auth request:

The url contains `tenant_id`, and the request options contain `client_secret`, `client_id` & `resource`, and for the response body the token itself is there.

To solve this, added a flag `log_data` to hide/show logs (that may contain sensitive data) in the client class, with a default value of true, and the Auth class passes false value.