### PR TITLE
feat(custom param): add custom param to url query

### DIFF
--- a/lib/msd_odata/entity.rb
+++ b/lib/msd_odata/entity.rb
@@ -59,6 +59,14 @@ module MsdOdata
       self
     end
 
+    # Adds a custom parameter to the url
+    # @param query_str [String]
+    # @return [self]
+    def custom_param(query_str)
+      @query[:custom_param] = query_str
+      self
+    end
+
     # Adds expressions to query.
     #
     # For example:

--- a/lib/msd_odata/util/url_helper.rb
+++ b/lib/msd_odata/util/url_helper.rb
@@ -10,13 +10,13 @@ module MsdOdata
         url = "#{@base_url}/data/#{@entity.name}"
 
         return url unless with_query
-        url + build_query
+        "#{url}#{build_query}"
       end
 
       def entity_url
         raise "'url_params' are missing." unless @entity.attrs[:url_params].is_a?(Hash)
 
-        "#{entity_collection_url}(#{build_url_params})"
+        "#{entity_collection_url}(#{build_url_params})#{build_query}"
       end
 
       private
@@ -25,12 +25,14 @@ module MsdOdata
       def build_query
         query = '?'
         query_hash = @entity.query
+        return if query_hash.empty?
         query += "$select=#{query_hash[:select]}&" unless query_hash[:select].nil?
         query += "$filter=#{query_hash[:filters]}&" unless query_hash[:filters].nil?
         query += "$orderby=#{query_hash[:order_by]}&" unless query_hash[:order_by].nil?
         query += "$top=#{query_hash[:top]}&" unless query_hash[:top].nil?
         query += "$expand=#{query_hash[:expand]}&" unless query_hash[:expand].nil?
         query += "$skip=#{query_hash[:skip]}&" unless query_hash[:skip].nil?
+        query += "#{query_hash[:custom_param]}&" unless query_hash[:custom_param].nil?
         query
       end
 

--- a/spec/lib/msd_odata/entity_spec.rb
+++ b/spec/lib/msd_odata/entity_spec.rb
@@ -71,6 +71,15 @@ describe 'MsdOdata::Entity' do
     end
   end
 
+  describe '.custom_param' do
+    before(:each) { @entity = MsdOdata::Entity.new('LedgerJournalHeaders') }
+
+    it 'uses custom param to add one param' do
+      @entity.custom_param('cross-company=true')
+      expect(@entity.query[:custom_param]).to eq('cross-company=true')
+    end
+  end
+
   describe '.where' do
     before(:each) { @entity = MsdOdata::Entity.new('ProductReceiptLines') }
 

--- a/spec/lib/msd_odata/service_spec.rb
+++ b/spec/lib/msd_odata/service_spec.rb
@@ -41,7 +41,7 @@ describe 'MsdOdata::Service' do
 
     it 'reads from a resource' do
       service = MsdOdata::Service.new(@token, @base_url, @entity)
-      expected_url = 'base_url.com/data/Customers?'
+      expected_url = 'base_url.com/data/Customers'
       actual_url = MsdOdata::Util::UrlHelper.new(@base_url, @entity).entity_collection_url(with_query: true)
 
       expect_any_instance_of(MsdOdata::Client).to receive(:request).with(:get, @expected_options)

--- a/spec/lib/msd_odata/util/url_helper_spec.rb
+++ b/spec/lib/msd_odata/util/url_helper_spec.rb
@@ -29,7 +29,7 @@ describe 'MsdOdata::Util::UrlHelper' do
       base_url = 'google.com'
       url_helper = MsdOdata::Util::UrlHelper.new(base_url, entity)
 
-      expected_url = "google.com/data/Invoices?"
+      expected_url = "google.com/data/Invoices"
       actual_url = url_helper.entity_collection_url(with_query: true)
       expect(actual_url).to eq(expected_url)
     end
@@ -44,6 +44,17 @@ describe 'MsdOdata::Util::UrlHelper' do
       expected_url = "github.com/data/Customers(CustomerId='HS-120')"
 
       expect(url_helper.entity_url).to eq(expected_url)
+    end
+
+    it 'builds url for entity with custom query param' do
+      entity = MsdOdata::Entity.new('Customers', { url_params: { 'CustomerAccount' => '10' } })
+      entity.custom_param('cross-company=true')
+      base_url = 'github.com'
+      url_helper = MsdOdata::Util::UrlHelper.new(base_url, entity)
+
+      expected_url = "github.com/data/Customers(CustomerAccount='10')?cross-company=true&"
+
+      expect(url_helper.entity_url).to eql(expected_url)
     end
   end
 


### PR DESCRIPTION
To enable using any param in the url, other than `OData system query options` that are built.

Usage: using `custom_param` method in the entity object, and passing a query string to it.